### PR TITLE
Hotfix: Fixed css flex is not applied to navbar

### DIFF
--- a/css/reset.css
+++ b/css/reset.css
@@ -25,7 +25,7 @@ time, mark, audio, video {
 }
 /* HTML5 display-role reset for older browsers */
 article, aside, details, figcaption, figure, 
-footer, header, hgroup, menu, nav, section {
+footer, header, hgroup, menu, section {
 	display: block;
 }
 body {


### PR DESCRIPTION
소수 Html 파일에서 Common Navbar의 display:flex가 적용되지 않던 현상 수정